### PR TITLE
Configurable cache location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ data/
 conf/certs/
 conf/raw.license
 raw-driver-logs/
+raw-cache/
 settings.*.sh
 !settings.default.sh

--- a/docker-compose-proxy.yml
+++ b/docker-compose-proxy.yml
@@ -122,3 +122,7 @@ services:
 volumes:
   postgres:
   cache:
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${RAW_CACHE}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,3 +100,7 @@ services:
 volumes:
   postgres:
   cache:
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${RAW_CACHE}"

--- a/settings.default.sh
+++ b/settings.default.sh
@@ -8,6 +8,7 @@
 
 : ${RAW_LICENSE:="./conf/raw.license"}
 : ${RAW_LOGS:="/tmp/raw-driver-logs"}
+: ${RAW_CACHE:="./raw-cache"}
 
 # RAW_DATA_* have to be absolute paths, as Spark does not allow relative ones.
 # Folder containing local data files.


### PR DESCRIPTION
By default docker volumes are created in /var/lib/docker/volumes... This
can be an issue when working with large cache values as this is generaly
located on the main system volume.

This changes the default behavior to be bind mounted to the provided
folder.

Notes: This has implication for multi-server deployment, but as this is
       not the target of these deployment scripts (yet), it does not
       matter.