### PR TITLE
Fix folder access

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,11 @@ then
 	exit 1
 fi
 
+# We can't commit empty folders in git, nor set access permissions on them,
+# and the folder has to exist for the bind mount to work, so we create them
+# here.
+test -d "${RAW_CACHE}" || mkdir -p "${RAW_CACHE}"
+
 if [ "$1" = "up" ]
 then
 	echo "-- Pulling images"


### PR DESCRIPTION
Bind mounts require the folder to exist before mounting, and unlike
regulare -v source:target, docker/docker-compose will not create the
folder when needed.

If the folder exists, AND is empty, docker/docker-compose will set the
permissions as required by the containers.

Git does not allows us to track empty folder AND does not allow us to
set rights on folders.

The solution, for now at least, is to check for the existance of the
folder, and if not, to create it from `run.sh` script.