### PR TITLE
RD-2496 docker-compose ./run.sh scripts must create a symmetric AES key if one does not exist on the 1st run.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,4 +9,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Shell Check
-        uses: ludeeus/action-shellcheck@1.0.0
+        uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          check_together: 'yes'

--- a/README.md
+++ b/README.md
@@ -30,12 +30,9 @@ Then Login to the docker registry with the following command `docker login artif
 
 
 The Credentials service requires a secret AES symmetric key in order to encrypt the credentials stored in the underlying database.
-One will be generated automatically the first time you run and stored in `settings.local.sh`.
-
-
+This will be generated automatically the first time you run RAW, but requires OpenSSL to be installed.
 
 **Note:** The following sections will assume the default values are used for the settings, adapt as needed if you make modifications.
-
 
 ### Basic setup
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ Then Login to the docker registry with the following command `docker login artif
 
 
 The Credentials service requires a secret AES symmetric key in order to encrypt the credentials stored in the underlying database.
-To generate the key, run:
-
-```
-$ openssl rand -base64 32
-```
-And assign the resulting key to the environment variable `RAW_CREDS_JDBC_ENCRYPTION_KEY` (this can be written in the `settings.local.sh` file, 
-as described above.
+One will be generated automatically the first time you run and stored in `settings.local.sh`.
 
 
 

--- a/settings.sh
+++ b/settings.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC1090,SC2013,SC2086
+# shellcheck disable=SC1090,SC1091,SC2013,SC2086
 
 # The MIT License (MIT)
 #
@@ -58,7 +58,6 @@ then
 fi
 
 #  4. Default settings `settings.default.sh`
-# shellcheck source=settings.default.sh
 . ${SCRIPT_DIR}/settings.default.sh
 
 if ${SHOW_SETTINGS}

--- a/settings.sh
+++ b/settings.sh
@@ -49,9 +49,7 @@ then
     export RAW_CREDS_JDBC_ENCRYPTION_KEY
     printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
   else
-    echo "Could not find openssl to generate credentials server encryption key."
-    echo "If you are in a Linux system try installing it with your distributions package manager eg.: apt or yum"
-    echo "If are using MacOs or Windows try searching for installation files for your operative system."
+    echo "Could not find OpenSSL, which is required to generate a server encryption key. Please install 'openssl' and try again."
     exit 1
   fi
 fi

--- a/settings.sh
+++ b/settings.sh
@@ -49,8 +49,8 @@ then
     printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
   else
     echo "Could not find openssl to generate credentials server encryption key."
-    echo "If you are in a debian based system try installing it with the command: 'apt install openssl'"
-    echo "If not check with your distributions package manager or get instructions in https://www.openssl.org/source/"
+    echo "If you are in a Linux system try installing it with your distributions package manager eg.: apt or yum"
+    echo "If are using MacOs or Windows try searching for installation files for your operative system."
     exit 1
   fi
 fi

--- a/settings.sh
+++ b/settings.sh
@@ -39,12 +39,19 @@ then
 	. ${SCRIPT_DIR}/settings.local.sh
 fi
 
-# creating a
+# checking if a encryption key for creds server exists, if not create a new one
 if [ -z "${RAW_CREDS_JDBC_ENCRYPTION_KEY}" ]
 then
-  echo "Generating RAW_CREDS_JDBC_ENCRYPTION_KEY and saving it in settings.local.sh"
-  export RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
-  printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
+  if openssl help 2> /dev/null
+  then
+    echo "Generating credentials server encryption key and saving it in settings.local.sh"
+    export RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
+    printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
+  else
+    echo "Could not find openssl to generate credentials server encryption key, please install it using the command:"
+    echo "apt install openssl"
+    exit 1
+  fi
 fi
 
 #  4. Default settings `settings.default.sh`

--- a/settings.sh
+++ b/settings.sh
@@ -36,7 +36,7 @@ fi
 #  2. Deployment-specific `settings.local.sh`
 if test -f ${SCRIPT_DIR}/settings.local.sh
 then
-    # shellcheck source=${SCRIPT_DIR}/settings.local.sh
+    # shellcheck disable=SC1091
 	. ${SCRIPT_DIR}/settings.local.sh
 fi
 
@@ -58,7 +58,7 @@ then
 fi
 
 #  4. Default settings `settings.default.sh`
-# shellcheck source=${SCRIPT_DIR}/settings.default.sh
+# shellcheck source=settings.default.sh
 . ${SCRIPT_DIR}/settings.default.sh
 
 if ${SHOW_SETTINGS}

--- a/settings.sh
+++ b/settings.sh
@@ -36,6 +36,7 @@ fi
 #  2. Deployment-specific `settings.local.sh`
 if test -f ${SCRIPT_DIR}/settings.local.sh
 then
+    # shellcheck source=${SCRIPT_DIR}/settings.local.sh
 	. ${SCRIPT_DIR}/settings.local.sh
 fi
 
@@ -45,7 +46,8 @@ then
   if openssl help 2> /dev/null
   then
     echo "Generating credentials server encryption key and saving it in settings.local.sh"
-    export RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
+    RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
+    export RAW_CREDS_JDBC_ENCRYPTION_KEY
     printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
   else
     echo "Could not find openssl to generate credentials server encryption key."
@@ -56,6 +58,7 @@ then
 fi
 
 #  4. Default settings `settings.default.sh`
+# shellcheck source=${SCRIPT_DIR}/settings.default.sh
 . ${SCRIPT_DIR}/settings.default.sh
 
 if ${SHOW_SETTINGS}

--- a/settings.sh
+++ b/settings.sh
@@ -36,7 +36,6 @@ fi
 #  2. Deployment-specific `settings.local.sh`
 if test -f ${SCRIPT_DIR}/settings.local.sh
 then
-    # shellcheck disable=SC1091
 	. ${SCRIPT_DIR}/settings.local.sh
 fi
 

--- a/settings.sh
+++ b/settings.sh
@@ -39,6 +39,15 @@ then
 	. ${SCRIPT_DIR}/settings.local.sh
 fi
 
+# creating a
+if [ -z "${RAW_CREDS_JDBC_ENCRYPTION_KEY}" ]
+then
+  encryption_key=$(openssl rand -base64 32)
+  echo "Generating RAW_CREDS_JDBC_ENCRYPTION_KEY and saving it in settings.local.sh"
+  export RAW_CREDS_JDBC_ENCRYPTION_KEY=encryption_key
+  printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=${encryption_key}}" >> settings.local.sh
+fi
+
 #  4. Default settings `settings.default.sh`
 . ${SCRIPT_DIR}/settings.default.sh
 

--- a/settings.sh
+++ b/settings.sh
@@ -42,10 +42,9 @@ fi
 # creating a
 if [ -z "${RAW_CREDS_JDBC_ENCRYPTION_KEY}" ]
 then
-  encryption_key=$(openssl rand -base64 32)
   echo "Generating RAW_CREDS_JDBC_ENCRYPTION_KEY and saving it in settings.local.sh"
-  export RAW_CREDS_JDBC_ENCRYPTION_KEY=encryption_key
-  printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=${encryption_key}}" >> settings.local.sh
+  export RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
+  printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
 fi
 
 #  4. Default settings `settings.default.sh`

--- a/settings.sh
+++ b/settings.sh
@@ -48,8 +48,9 @@ then
     export RAW_CREDS_JDBC_ENCRYPTION_KEY=$(openssl rand -base64 32)
     printf  "\n: \${RAW_CREDS_JDBC_ENCRYPTION_KEY:=\"%s\"}" "$RAW_CREDS_JDBC_ENCRYPTION_KEY">> settings.local.sh
   else
-    echo "Could not find openssl to generate credentials server encryption key, please install it using the command:"
-    echo "apt install openssl"
+    echo "Could not find openssl to generate credentials server encryption key."
+    echo "If you are in a debian based system try installing it with the command: 'apt install openssl'"
+    echo "If not check with your distributions package manager or get instructions in https://www.openssl.org/source/"
     exit 1
   fi
 fi

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2064,SC2206,SC2128
+# shellcheck disable=SC2086,SC2064,SC2206,SC2128,SC2260
 # Use this script to test if a given TCP host/port are available
 
 set -x


### PR DESCRIPTION
So I am generating a key if it does not exist and appending it to `settings.local.sh`. 
Like that next time it will use it.

Please let me know if writing a separate file would be better.
